### PR TITLE
Performance and utility improvements

### DIFF
--- a/cache-utils.js
+++ b/cache-utils.js
@@ -30,6 +30,16 @@ var cacheUtils = {
     return { requests: {}, keys: {} };
   },
 
+  clear: function( cache ) {
+    cache.requests = {};
+    cache.keys = {};
+  },
+
+  size: function( cache ) {
+    return { requests: Object.keys(cache.requests).length,
+             keys: Object.keys(cache.keys).length };
+  },
+
   objectCacheKey: function( source ) {
     return JSON.stringify( sortObject( source ) );
   },

--- a/cache-utils.js
+++ b/cache-utils.js
@@ -12,7 +12,11 @@ function sortObject( source ) {
     return source.map( function(item) { return sortObject(item); } );
   } else if( source instanceof Object ){
     var sortedObject = {};
-    Object.keys(source || {}).sort().map( function(key) {
+    // TODO sorting keys does not matter (spec does not guarantee order any way).
+    // removed for performance.
+    // should think of different approach...
+    // e.g. limited set of keys, getting them in order and appending to string
+    Object.keys(source).map( function(key) {
       sortedObject[key] = sortObject(source[key]);
     } );
     return sortedObject;

--- a/cache-utils.js
+++ b/cache-utils.js
@@ -79,11 +79,14 @@ var cacheUtils = {
         // remove the entry
         delete cache.requests[entry];
         // remove the keys of this entry from the interested keys
-        // logger.info("Removing cached entry: " + JSON.stringify(currentEntry));
-        currentEntry.keys.forEach( function( keyToRemove ) {
-          // logger.info("Removing cached content: " + JSON.stringify(keyToRemove));
-          delete cache.keys[keyToRemove][currentEntry.requestKey];
-        } );
+        // but only if we are interested in preserving memory
+        if (process.env.PRESERVE_MEMORY) {
+          // logger.info("Removing cached entry: " + JSON.stringify(currentEntry));
+          currentEntry.keys.forEach( function( keyToRemove ) {
+            // logger.info("Removing cached content: " + JSON.stringify(keyToRemove));
+            delete cache.keys[keyToRemove][currentEntry.requestKey];
+          } );
+        }
       } );
       delete cache.keys[key];
     } );

--- a/index.js
+++ b/index.js
@@ -36,6 +36,16 @@ var server = http.createServer(function(request, response) {
 
     writeResponseJSON(response, 405, {});
     return;
+  } else if (request.method === "POST" && request.url == "/clear") {
+    cacheUtils.clear(cache);
+    logger.info("Cleared cache");
+    writeResponseJSON(response, 200, {"status": "ok"});
+    return;
+  } else if (request.method === "GET" && request.url == "/size") {
+    size = cacheUtils.size(cache);
+    logger.info("Cleared cache");
+    writeResponseJSON(response, 200, size);
+    return;
   }
 
   // Try to hit the cache

--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ var server = http.createServer(function(request, response) {
     return;
   }
 
+  logger.info("Cache miss for " + request.method + " " + request.url);
   // Forward request to proxy
   proxy.web(request, response, {
     target: cacheBackend


### PR DESCRIPTION
Hi,
Some changes for your review :)
- performance improvement: not sorting keys as does not help according to spec. Need other solution in long run as depending on same key order from backend and node.js key order preservation
- utility functions for clearing cache and getting its size
- performance improvement: do not remove request keys from memory unless specified. speed >> memory by default
- log cache misses as also logging cache hits
- always strip keys, also when clearing them
