### PR TITLE
fixed bug with double slash

### DIFF
--- a/lib/use_plug_proxy.ex
+++ b/lib/use_plug_proxy.ex
@@ -62,7 +62,7 @@ defmodule UsePlugProxy do
   end
 
   defp calculate_response_from_backend(full_path, conn) do
-    url = "http://backend/" <> full_path
+    url = "http://backend" <> full_path #Full path starts with /
 
     url =
       if conn.query_string do


### PR DESCRIPTION
I paired with Aad and we discovered mu-cache had a bug related to the inclusion of double `/` in the path sent to the microservice, for example if the request to mu-cache was `/getInfo` the microservice would receive `//getInfo`.
This issue doesn't affect mu-cl-resources because the microservice accepts this double slash query without any problems.
We tested with a local build and everything worked fine